### PR TITLE
fix: background mesh gradient

### DIFF
--- a/style.css
+++ b/style.css
@@ -45,6 +45,7 @@ body {
   overflow-x: hidden;
   margin-top: 2rem;
   background-image: url(/assets/hero.svg);
+  background-size: cover;
   background-repeat: no-repeat;
 }
 


### PR DESCRIPTION
Fix landing page mesh gradient background size in screens with resolutions above 1920x1080.

* Before
![image](https://github.com/user-attachments/assets/b3dfada2-4d17-4747-a7c9-519b18dac657)

* After
![image](https://github.com/user-attachments/assets/9806f304-be76-446e-b6db-629d446ce95b)
